### PR TITLE
AF2 that do not need local database

### DIFF
--- a/run_alphafold.py
+++ b/run_alphafold.py
@@ -433,9 +433,9 @@ def main(argv):
     num_predictions_per_model = 1
 
     # the feature.pkl should already exist, otherwise rise error
-    feature_file_list = [os.path.join(FLAGS.output_dir, fasta_name, 'feature.pkl') 
+    feature_file_list = [os.path.join(FLAGS.output_dir, fasta_name, 'features.pkl') 
                          for fasta_name in fasta_names]
-    missing_files = [file for file in file_paths if not os.path.isfile(file)]
+    missing_files = [file for file in feature_file_list if not os.path.isfile(file)]
     if missing_files:
       raise FileNotFoundError(f"Error: The following files do not exist: {', '.join(missing_files)}")
     

--- a/run_alphafold.py
+++ b/run_alphafold.py
@@ -98,11 +98,11 @@ flags.DEFINE_string('obsolete_pdbs_path', None, 'Path to file containing a '
                     'mapping from obsolete PDB IDs to the PDB IDs of their '
                     'replacements.')
 flags.DEFINE_enum('db_preset', 'full_dbs',
-                  ['full_dbs', 'reduced_dbs', 'none'],
+                  ['full_dbs', 'reduced_dbs', 'none_dbs'],
                   'Choose preset MSA database configuration - '
                   'smaller genetic database config (reduced_dbs) or '
                   'full genetic database config  (full_dbs) or '
-                  'no MSA at all  (none)')
+                  'no MSA at all  (none_dbs)')
 flags.DEFINE_enum('model_preset', 'monomer',
                   ['monomer', 'monomer_casp14', 'monomer_ptm', 'multimer'],
                   'Choose preset model configuration - the monomer model, '
@@ -176,16 +176,17 @@ def _jnp_to_np(output: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def predict_structure(
-    fasta_path: str,
-    fasta_name: str,
-    output_dir_base: str,
-    data_pipeline: Union[pipeline.DataPipeline, pipeline_multimer.DataPipeline],
-    model_runners: Dict[str, model.RunModel],
-    amber_relaxer: relax.AmberRelaxation,
-    benchmark: bool,
-    random_seed: int,
-    models_to_relax: ModelsToRelax,
-    run_feature: bool):
+  fasta_path: str,
+  fasta_name: str,
+  output_dir_base: str,
+  data_pipeline: Union[pipeline.DataPipeline, pipeline_multimer.DataPipeline],
+  model_runners: Dict[str, model.RunModel],
+  amber_relaxer: relax.AmberRelaxation,
+  benchmark: bool,
+  random_seed: int,
+  models_to_relax: ModelsToRelax,
+  run_feature: bool):
+    
   """Predicts structure using AlphaFold for the given sequence."""
   logging.info('Predicting %s', fasta_name)
   timings = {}
@@ -195,11 +196,6 @@ def predict_structure(
   msa_output_dir = os.path.join(output_dir, 'msas')
   if not os.path.exists(msa_output_dir):
     os.makedirs(msa_output_dir)
-  
-  #if does not use MSA, create an empty features.pkl
-  if FLAGS.db_preset=='none':
-    from parafold.create_empty_feature import empty_feature
-    empty_feature(fasta_path,output_dir)
 
   # Get features.
   t_0 = time.time()
@@ -344,7 +340,7 @@ def predict_structure(
       f.write(json.dumps(relax_metrics, indent=4))
 
 def get_data_pipeline():
-"""get the data_pipline, can be skipped if MSA is skipped"""
+  """get the data_pipline, can be skipped if MSA is skipped"""
   for tool_name in (
       'jackhmmer', 'hhblits', 'hhsearch', 'hmmsearch', 'hmmbuild', 'kalign'):
     if not FLAGS[f'{tool_name}_binary_path'].value:
@@ -366,11 +362,6 @@ def get_data_pipeline():
               should_be_set=run_multimer_system)
   _check_flag('uniprot_database_path', 'model_preset',
               should_be_set=run_multimer_system)
-
-  if FLAGS.model_preset == 'monomer_casp14':
-    num_ensemble = 8
-  else:
-    num_ensemble = 1
 
   # Check for duplicate FASTA file names.
   fasta_names = [pathlib.Path(p).stem for p in FLAGS.fasta_paths]
@@ -428,15 +419,23 @@ def main(argv):
   if len(argv) > 1:
     raise app.UsageError('Too many command-line arguments.')
 
+  if FLAGS.db_preset!='none_dbs':
+    data_pipeline=get_data_pipeline()
+  else:
+    data_pipeline=None
+    
+  run_multimer_system = 'multimer' in FLAGS.model_preset
   if run_multimer_system:
     num_predictions_per_model = FLAGS.num_multimer_predictions_per_model
   else:
     num_predictions_per_model = 1
-  
-  if FLAGS.db_preset!='none':
-    data_pipeline=get_data_pipeline()
+    
+  if FLAGS.model_preset == 'monomer_casp14':
+    num_ensemble = 8
   else:
-    data_pipeline=None
+    num_ensemble = 1
+    
+  fasta_names = [pathlib.Path(p).stem for p in FLAGS.fasta_paths]
     
   model_runners = {}
   if FLAGS.model_names:

--- a/run_alphafold.py
+++ b/run_alphafold.py
@@ -423,19 +423,26 @@ def main(argv):
     data_pipeline=get_data_pipeline()
   else:
     data_pipeline=None
-    
+
+  fasta_names = [pathlib.Path(p).stem for p in FLAGS.fasta_paths]
+  
   run_multimer_system = 'multimer' in FLAGS.model_preset
   if run_multimer_system:
     num_predictions_per_model = FLAGS.num_multimer_predictions_per_model
   else:
     num_predictions_per_model = 1
+
+    # the feature.pkl should already exist, otherwise rise error
+    feature_file_list = [os.path.join(FLAGS.output_dir, fasta_name, 'feature.pkl') 
+                         for fasta_name in fasta_names]
+    missing_files = [file for file in file_paths if not os.path.isfile(file)]
+    if missing_files:
+      raise FileNotFoundError(f"Error: The following files do not exist: {', '.join(missing_files)}")
     
   if FLAGS.model_preset == 'monomer_casp14':
     num_ensemble = 8
   else:
     num_ensemble = 1
-    
-  fasta_names = [pathlib.Path(p).stem for p in FLAGS.fasta_paths]
     
   model_runners = {}
   if FLAGS.model_names:

--- a/run_alphafold.py
+++ b/run_alphafold.py
@@ -343,7 +343,7 @@ def predict_structure(
     with open(relax_metrics_path, 'w') as f:
       f.write(json.dumps(relax_metrics, indent=4))
 
-def get_data_pipline(argv):
+def get_data_pipeline():
 """get the data_pipline, can be skipped if MSA is skipped"""
   for tool_name in (
       'jackhmmer', 'hhblits', 'hhsearch', 'hmmsearch', 'hmmbuild', 'kalign'):
@@ -434,7 +434,7 @@ def main(argv):
     num_predictions_per_model = 1
   
   if FLAGS.db_preset!='none':
-    data_pipeline=get_data_pipline(argv)
+    data_pipeline=get_data_pipeline()
   else:
     data_pipeline=None
     


### PR DESCRIPTION
Hi,

I added one more option in `db_preset`, called `none_db`. With this option, the `data_pipline` is skipped, and will use the features.pkl created by your `create_empty_feature.py ` for `feature_dict `.

As `data_pipline` is skipped, it does not go through the `template_searcher ` and `template_featurizer `, and go not need to have the folders for the database. 